### PR TITLE
Code trigger, high res images, and close event

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ import { IonicImageViewerModule } from 'ionic-img-viewer';
 export class AppModule {}
 ```
 
-## Usage
+## Usage as a directive
 
 Add the `imageViewer` property to the pictures.
 
@@ -52,6 +52,39 @@ If you use thumbnails and want to display bigger images, you can use it like so 
 
 However, if `OTHER_IMAGE_URL` is not preloaded, the animation might suffer. Indeed there will be no ready image to make the transition (it might blink and you'll not get the smooth transition effet while opening).
 So try to cache your image before the call if you use it that way.
+
+If you need to, you can attach a callback to the `onClose` event, fired right after the image viewer element has been closed :
+
+```html
+<img src="IMAGE_URL" imageViewer (onClose)="callbackAfterImageviewerCloses()" />
+```
+
+## Programmatic usage
+
+If you don't want to use the directive, you can create an instance of an ImageViewer yourself, and trigger the presentation when you want.
+
+```html
+<img src="IMAGE_URL" #myImage />
+```
+
+```typescript
+import { ImageViewerController } from 'ionic-img-viewer';
+
+export class MyPage {
+  constructor(public imageViewerCtrl: ImageViewerController) {
+  }
+
+  presentImage() {
+    let imageViewer = this.imageViewerCtrl.create(myImage);
+    imageViewer.present();
+  }
+}
+```
+
+| Options         | Type     | Description  |
+| --------------- |:---------| :------------|
+| image           | string   | The image path. Default to the `src` of the element passed as first param  |
+| onCloseCallback | Function | Function to be called when the ImageViewer quits. Default to null |
 
 # Contributing
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,9 @@ Make sure you have Ionic and Angular installed.
 npm install --save ionic-img-viewer
 ```
 
-**For Ionic 2 RC.0 and later:**
+**Check you peer-dependencies warnings after `npm install` to make sure you are using a version in accordance to your Ionic version.**
+
+### For Ionic 2 RC.0 and later:
 
 ```typescript
 import { IonicImageViewerModule } from 'ionic-img-viewer';
@@ -36,9 +38,12 @@ import { IonicImageViewerModule } from 'ionic-img-viewer';
 export class AppModule {}
 ```
 
-## Usage as a directive
+## Usage
 
-Add the `imageViewer` property to the pictures.
+
+### As a directive
+
+Add the `imageViewer` property to the image element.
 
 ```html
 <img src="IMAGE_URL" imageViewer />
@@ -50,36 +55,44 @@ If you use thumbnails and want to display bigger images, you can use it like so 
 <img src="IMAGE_URL" imageViewer="OTHER_IMAGE_URL" />
 ```
 
-However, if `OTHER_IMAGE_URL` is not preloaded, the animation might suffer. Indeed there will be no ready image to make the transition (it might blink and you'll not get the smooth transition effet while opening).
+However, if `OTHER_IMAGE_URL` is not preloaded, the animation might suffer. There will be no loaded image to display in order to have the nice and smooth transition, and you might see the image blinking while opening it.
+
 So try to cache your image before the call if you use it that way.
 
-If you need to, you can attach a callback to the `onClose` event, fired right after the image viewer element has been closed :
+### React to close event
+
+If you need to, you can attach a callback to `close` event, fired right after the image viewer element has been closed :
 
 ```html
-<img src="IMAGE_URL" imageViewer (onClose)="callbackAfterImageviewerCloses()" />
+<img src="IMAGE_URL" imageViewer (close)="callbackAfterImageViewerCloses()" />
 ```
 
-## Programmatic usage
+### Programmatic usage
 
-If you don't want to use the directive, you can create an instance of an ImageViewer yourself, and trigger the presentation when you want.
+If you don't want to use the directive, you can create an instance of the ImageViewer yourself, and trigger the presentation whenever you want.
 
 ```html
-<img src="IMAGE_URL" #myImage />
+<img src="IMAGE_URL" #myImage (click)="presentImage(myImage)" />
 ```
 
 ```typescript
 import { ImageViewerController } from 'ionic-img-viewer';
 
 export class MyPage {
-  constructor(public imageViewerCtrl: ImageViewerController) {
+  _imageViewerCtrl: ImageViewerController;
+
+  constructor(imageViewerCtrl: ImageViewerController) {
+    this._imageViewerCtrl = imageViewerCtrl;
   }
 
-  presentImage() {
-    let imageViewer = this.imageViewerCtrl.create(myImage);
+  presentImage(myImage) {
+    const imageViewer = this._imageViewerCtrl.create(myImage);
     imageViewer.present();
   }
 }
 ```
+
+As a second argument to the `create(imageElement, config)` method, you can pass an object with the following options.
 
 | Options         | Type     | Description  |
 | --------------- |:---------| :------------|

--- a/README.md
+++ b/README.md
@@ -96,7 +96,6 @@ As a second argument to the `create(imageElement, config)` method, you can pass 
 
 | Options         | Type     | Description  |
 | --------------- |:---------| :------------|
-| image           | string   | The image path. Default to the `src` of the element passed as first param  |
 | fullResImage    | string   | A full resolution image to display instead of the original image when open. Default to null |
 | onCloseCallback | Function | Function to be called when the ImageViewer quits. Default to null |
 

--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ As a second argument to the `create(imageElement, config)` method, you can pass 
 | Options         | Type     | Description  |
 | --------------- |:---------| :------------|
 | image           | string   | The image path. Default to the `src` of the element passed as first param  |
+| fullResImage    | string   | A full resolution image to display instead of the original image when open. Default to null |
 | onCloseCallback | Function | Function to be called when the ImageViewer quits. Default to null |
 
 # Contributing

--- a/ionic-img-viewer.ts
+++ b/ionic-img-viewer.ts
@@ -1,4 +1,5 @@
 export { IonicImageViewerModule } from './src/module';
 export { ImageViewerComponent } from './src/image-viewer.component';
 export { ImageViewerDirective } from './src/image-viewer.directive';
+export { ImageViewerController } from './src/image-viewer.controller';
 export { ImageViewer } from './src/image-viewer';

--- a/src/image-viewer-impl.ts
+++ b/src/image-viewer-impl.ts
@@ -18,6 +18,15 @@ export class ImageViewerImpl extends ViewController {
 		this.willEnter.subscribe(() => this.handleHighResImageLoad(opts.fullResImage));
 	}
 
+	getTransitionName(direction: string) {
+		let key = 'image-viewer-' + (direction === 'back' ? 'leave' : 'enter');
+		return key;
+	}
+
+	present(navOptions: NavOptions = {}) {
+		return this.app.present(this, navOptions);
+	}
+
 	private handleHighResImageLoad(fullResImage){
 		if (!fullResImage) {
 			return;
@@ -37,19 +46,10 @@ export class ImageViewerImpl extends ViewController {
 			// We want the animation to finish before replacing the pic
 			// as the calculation has been done with the smaller image
 			Observable.zip(onLoadObservable, this.didEnter)
-				.subscribe(() => this.instance.updateImageSrc(fullResImage));
+				.subscribe(() => this.instance.updateImageSrcWithTransition(fullResImage));
 
 		} else {
 			this.instance.updateImageSrc(fullResImage)
 		}
-	}
-
-	getTransitionName(direction: string) {
-		let key = 'image-viewer-' + (direction === 'back' ? 'leave' : 'enter');
-		return key;
-	}
-
-	present(navOptions: NavOptions = {}) {
-		return this.app.present(this, navOptions);
 	}
 }

--- a/src/image-viewer-impl.ts
+++ b/src/image-viewer-impl.ts
@@ -1,17 +1,47 @@
-import { App, Config, ViewController, NavOptions } from 'ionic-angular';
+import { App, Config, NavOptions, ViewController } from 'ionic-angular';
+import { Observable } from 'rxjs/Rx';
 
 import { ImageViewerOptions } from './image-viewer';
 import { ImageViewerEnter, ImageViewerLeave } from './image-viewer-transitions';
+import { ImageViewerComponent } from "./image-viewer.component";
 
 export class ImageViewerImpl extends ViewController {
 
-	constructor(private app: App, component: any, opts: ImageViewerOptions = {}, config: Config) {
+	constructor(private app: App, component: ImageViewerComponent, opts: ImageViewerOptions = {}, config: Config) {
 		super(component, opts);
 
 		config.setTransition('image-viewer-enter', ImageViewerEnter);
 		config.setTransition('image-viewer-leave', ImageViewerLeave);
 
 		this.didLeave.subscribe(() => opts.onCloseCallback && opts.onCloseCallback());
+
+		this.willEnter.subscribe(() => this.handleHighResImageLoad(opts.fullResImage));
+	}
+
+	private handleHighResImageLoad(fullResImage){
+		if (!fullResImage) {
+			return;
+		}
+
+		const image = new Image();
+		image.src = fullResImage;
+
+		if (!image.complete) {
+			const onLoadObservable = Observable.create(obs => {
+				image.onload = () => {
+					obs.next(image);
+					obs.complete();
+				}
+			});
+
+			// We want the animation to finish before replacing the pic
+			// as the calculation has been done with the smaller image
+			Observable.zip(onLoadObservable, this.didEnter)
+				.subscribe(() => this.instance.updateImageSrc(fullResImage));
+
+		} else {
+			this.instance.updateImageSrc(fullResImage)
+		}
 	}
 
 	getTransitionName(direction: string) {

--- a/src/image-viewer-src-animation.ts
+++ b/src/image-viewer-src-animation.ts
@@ -1,0 +1,21 @@
+import { Animation, Platform } from 'ionic-angular';
+
+export class ImageViewerSrcAnimation {
+	private imageAnimation: Animation;
+	private element: HTMLElement;
+
+	constructor(platform: Platform, image: any) {
+		this.element = image.nativeElement;
+		this.imageAnimation = new Animation(platform, image);
+	}
+
+	scaleFrom(lowResImgWidth) {
+		const highResImgWidth = this.element.clientWidth;
+
+		const imageTransition = this.imageAnimation
+			.fromTo('scale', lowResImgWidth / highResImgWidth, 1)
+			.duration(100)
+			.easing('ease-in-out')
+			.play();
+	}
+}

--- a/src/image-viewer-transitions.ts
+++ b/src/image-viewer-transitions.ts
@@ -3,6 +3,7 @@ import { Transition, Animation } from 'ionic-angular';
 export class ImageViewerEnter extends Transition {
 	init() {
 
+		const css = this.plt.Css;
 		const ele = this.enteringView.pageRef().nativeElement;
 
 		const fromPosition = this.enteringView.data.position;
@@ -11,14 +12,17 @@ export class ImageViewerEnter extends Transition {
 		const flipY = fromPosition.top - toPosition.top;
 		const flipX = fromPosition.left - toPosition.left;
 
+		const imgElement = ele.querySelector('.image');
 		const backdrop = new Animation(this.plt, ele.querySelector('ion-backdrop'));
-		const image = new Animation(this.plt, ele.querySelector('.image'));
+		const image = new Animation(this.plt, imgElement);
+
+		// Using `Animation.beforeStyles()` here does not seems to work
+		imgElement.style[css.transformOrigin] = '0 0';
 
 		image.fromTo('translateY', `${flipY}px`, '0px')
 			.fromTo('translateX', `${flipX}px`, '0px')
 			.fromTo('scale', flipS, '1')
-			.beforeStyles({ 'transform-origin': '0 0' })
-			.afterClearStyles(['transform-origin']);
+			.afterClearStyles([ css.transformOrigin ]);
 
 		backdrop.fromTo('opacity', '0.01', '1');
 
@@ -32,25 +36,28 @@ export class ImageViewerEnter extends Transition {
 		const enteringBackBtnEle = enteringPageEle.querySelector('.back-button');
 
 		const enteringNavBar = new Animation(this.plt, enteringNavbarEle);
-		enteringNavBar.beforeAddClass('show-navbar');
+		enteringNavBar.afterAddClass('show-navbar');
 		this.add(enteringNavBar);
 
 		const enteringBackButton = new Animation(this.plt, enteringBackBtnEle);
 		this.add(enteringBackButton);
-		enteringBackButton.beforeAddClass('show-back-button');
+		enteringBackButton.afterAddClass('show-back-button');
 	}
 }
 
 export class ImageViewerLeave extends Transition {
 	init() {
 
+		const css = this.plt.Css;
 		const ele = this.leavingView.pageRef().nativeElement;
 
 		const toPosition = this.leavingView.data.position;
 		const fromPosition = ele.querySelector('img').getBoundingClientRect();
 
+		const imageElement = ele.querySelector('.image');
+
 		let offsetY = 0;
-		const imageYOffset = ele.querySelector('.image').style[this.plt.Css.transform];
+		const imageYOffset = imageElement.style[css.transform];
 		if (imageYOffset) {
 			const regexResult = imageYOffset.match(/translateY\((-?\d*\.?\d*)px\)/);
 			offsetY = regexResult ? parseFloat(regexResult[1]) : offsetY;
@@ -63,13 +70,13 @@ export class ImageViewerLeave extends Transition {
 		const backdropOpacity = ele.querySelector('ion-backdrop').style['opacity'];
 
 		const backdrop = new Animation(this.plt, ele.querySelector('ion-backdrop'));
-		const image = new Animation(this.plt, ele.querySelector('.image'));
+		const image = new Animation(this.plt, imageElement);
 
 		image.fromTo('translateY', `${offsetY}px`, `${flipY}px`)
 			.fromTo('translateX', `0px`, `${flipX}px`)
 			.fromTo('scale', '1', flipS)
-			.beforeStyles({ 'transform-origin': '0 0' })
-			.afterClearStyles(['transform-origin']);
+			.beforeStyles({ [css.transformOrigin]: '0 0' })
+			.afterClearStyles([css.transformOrigin]);
 
 		backdrop.fromTo('opacity', backdropOpacity, '0');
 

--- a/src/image-viewer.component.ts
+++ b/src/image-viewer.component.ts
@@ -57,12 +57,16 @@ export class ImageViewerComponent extends Ion implements OnInit, OnDestroy, Afte
 		private platform: Platform,
 		_navParams: NavParams,
 		_config: Config,
-		_sanitizer: DomSanitizer
+		private _sanitizer: DomSanitizer
 	) {
 		super(_config, elementRef, renderer);
 
 		const url = _navParams.get('image');
 		this.imageUrl = _sanitizer.bypassSecurityTrustUrl(url);
+	}
+
+	updateImageSrc(src) {
+		this.imageUrl = this._sanitizer.bypassSecurityTrustUrl(src);
 	}
 
 	ngOnInit() {

--- a/src/image-viewer.component.ts
+++ b/src/image-viewer.component.ts
@@ -8,12 +8,14 @@ import {
 	Gesture,
 	GestureController,
 	Config,
-	Platform
+	Platform,
+    Animation
 } from 'ionic-angular';
 import { DIRECTION_HORIZONTAL, DIRECTION_VERTICAL } from 'ionic-angular/gestures/hammer';
 import { ElementRef, Renderer, Component, OnInit, OnDestroy, AfterViewInit, NgZone, ViewChild } from '@angular/core';
 import { DomSanitizer, SafeUrl } from '@angular/platform-browser';
 
+import { ImageViewerSrcAnimation } from './image-viewer-src-animation';
 import { ImageViewerTransitionGesture } from './image-viewer-transition-gesture';
 import { ImageViewerZoomGesture } from './image-viewer-zoom-gesture';
 import { ImageViewerEnter, ImageViewerLeave } from './image-viewer-transitions';
@@ -30,7 +32,7 @@ import { ImageViewerEnter, ImageViewerLeave } from './image-viewer-transitions';
 
 		<div class="image-wrapper">
 			<div class="image" #imageContainer>
-				<img [src]="imageUrl" tappable />
+				<img [src]="imageUrl" tappable #image />
 			</div>
 		</div>
 	`
@@ -41,6 +43,8 @@ export class ImageViewerComponent extends Ion implements OnInit, OnDestroy, Afte
 	public dragGesture: ImageViewerTransitionGesture;
 
 	@ViewChild('imageContainer') imageContainer;
+	@ViewChild('image') image;
+
 	private pinchGesture: ImageViewerZoomGesture;
 
 	public isZoomed: boolean;
@@ -62,11 +66,21 @@ export class ImageViewerComponent extends Ion implements OnInit, OnDestroy, Afte
 		super(_config, elementRef, renderer);
 
 		const url = _navParams.get('image');
-		this.imageUrl = _sanitizer.bypassSecurityTrustUrl(url);
+		this.updateImageSrc(url);
 	}
 
 	updateImageSrc(src) {
 		this.imageUrl = this._sanitizer.bypassSecurityTrustUrl(src);
+	}
+
+	updateImageSrcWithTransition(src) {
+		const imageElement = this.image.nativeElement;
+		const lowResImgWidth = imageElement.clientWidth;
+
+		this.updateImageSrc(src);
+
+		const animation = new ImageViewerSrcAnimation(this.platform, this.image);
+		imageElement.onload = () => animation.scaleFrom(lowResImgWidth);
 	}
 
 	ngOnInit() {

--- a/src/image-viewer.controller.ts
+++ b/src/image-viewer.controller.ts
@@ -1,0 +1,26 @@
+import { Injectable } from '@angular/core';
+import { App, Config, DeepLinker } from "ionic-angular";
+
+import { ImageViewerOptions, ImageViewer } from './image-viewer';
+import { ImageViewerComponent } from './image-viewer.component';
+
+@Injectable()
+export class ImageViewerController {
+
+  constructor(private _app: App, public config: Config, private deepLinker: DeepLinker) { }
+
+  /**
+   * Create a image-viewer instance to display. See below for options.
+   *
+   * @param {object} imageElement The image element
+   * @param {object} opts ImageViewer options
+   */
+  create(imageElement: any,  opts: ImageViewerOptions = {}) {
+    const image = imageElement.src;
+    const position = imageElement.getBoundingClientRect();
+
+    const options = { image, position, ...opts };
+
+    return new ImageViewer(this._app, ImageViewerComponent, options, this.config, this.deepLinker);
+  }
+}

--- a/src/image-viewer.directive.ts
+++ b/src/image-viewer.directive.ts
@@ -3,6 +3,7 @@ import { Directive, ElementRef, EventEmitter, HostListener, Input, Output } from
 
 import { ImageViewerComponent } from './image-viewer.component';
 import { ImageViewer } from './image-viewer';
+import { ImageViewerController } from "./image-viewer.controller";
 
 @Directive({
 	selector: '[imageViewer]'
@@ -12,18 +13,21 @@ export class ImageViewerDirective {
 	@Input('imageViewer') src: string;
 	@Output() close = new EventEmitter();
 
-	constructor(private _app: App, private _el: ElementRef, private config: Config, private deepLinker: DeepLinker) { }
+	constructor(
+		private _app: App,
+		private _el: ElementRef,
+		private config: Config,
+		private deepLinker: DeepLinker,
+		private imageViewerCtrl: ImageViewerController
+	) { }
 
 	@HostListener('click', ['$event']) onClick(event: Event): void {
 		event.stopPropagation();
 
-		const image = this.src || this._el.nativeElement.src;
-		const position = this._el.nativeElement.getBoundingClientRect();
-		const onCloseCallback = () => this.close.emit()
+		const element = this._el.nativeElement;
+		const onCloseCallback = () => this.close.emit();
 
-		const options = { image, position, onCloseCallback };
-
-		const imageViewer =  new ImageViewer(this._app, ImageViewerComponent, options, this.config, this.deepLinker);
+		const imageViewer = this.imageViewerCtrl.create(element, { fullResImage: this.src, onCloseCallback });
 		imageViewer.present();
 	}
 }

--- a/src/image-viewer.directive.ts
+++ b/src/image-viewer.directive.ts
@@ -10,7 +10,7 @@ import { ImageViewer } from './image-viewer';
 export class ImageViewerDirective {
 
 	@Input('imageViewer') src: string;
-	@Output() onClose = new EventEmitter();
+	@Output() close = new EventEmitter();
 
 	constructor(private _app: App, private _el: ElementRef, private config: Config, private deepLinker: DeepLinker) { }
 
@@ -19,7 +19,7 @@ export class ImageViewerDirective {
 
 		const image = this.src || this._el.nativeElement.src;
 		const position = this._el.nativeElement.getBoundingClientRect();
-		const onCloseCallback = () => this.onClose.emit()
+		const onCloseCallback = () => this.close.emit()
 
 		const options = { image, position, onCloseCallback };
 

--- a/src/image-viewer.directive.ts
+++ b/src/image-viewer.directive.ts
@@ -1,4 +1,3 @@
-import { App, Config, DeepLinker } from 'ionic-angular';
 import { Directive, ElementRef, EventEmitter, HostListener, Input, Output } from '@angular/core';
 
 import { ImageViewerComponent } from './image-viewer.component';
@@ -14,10 +13,7 @@ export class ImageViewerDirective {
 	@Output() close = new EventEmitter();
 
 	constructor(
-		private _app: App,
 		private _el: ElementRef,
-		private config: Config,
-		private deepLinker: DeepLinker,
 		private imageViewerCtrl: ImageViewerController
 	) { }
 

--- a/src/image-viewer.ts
+++ b/src/image-viewer.ts
@@ -3,10 +3,11 @@ import { Overlay } from "ionic-angular/navigation/overlay";
 import { OverlayProxy } from "ionic-angular/navigation/overlay-proxy";
 
 import { ImageViewerImpl } from './image-viewer-impl';
+import { ImageViewerComponent } from "./image-viewer.component";
 
 export class ImageViewer extends OverlayProxy {
 
-	constructor(app: App, component: any, private opts: ImageViewerOptions = {}, config: Config, deepLinker: DeepLinker) {
+	constructor(app: App, component: typeof ImageViewerComponent, private opts: ImageViewerOptions = {}, config: Config, deepLinker: DeepLinker) {
 		super(app, component, config, deepLinker);
 	}
 
@@ -18,6 +19,7 @@ export class ImageViewer extends OverlayProxy {
 export interface ImageViewerOptions {
 	enableBackdropDismiss?: boolean;
 	image?: string;
+	fullResImage?: string
 	position?: ClientRect;
 	onCloseCallback?: Function;
 }

--- a/src/module.ts
+++ b/src/module.ts
@@ -4,6 +4,7 @@ import { Config } from 'ionic-angular/config/config';
 
 import { ImageViewerDirective } from './image-viewer.directive';
 import { ImageViewerComponent } from './image-viewer.component';
+import { ImageViewerController } from "./image-viewer.controller";
 
 @NgModule({
 	imports: [IonicModule],
@@ -11,6 +12,7 @@ import { ImageViewerComponent } from './image-viewer.component';
 		ImageViewerComponent,
 		ImageViewerDirective
 	],
+	providers: [ ImageViewerController ],
 	exports: [ ImageViewerDirective ],
 	entryComponents: [ ImageViewerComponent ]
 })


### PR DESCRIPTION
- Fixes several issues : #65, #63 and #42
- Better high resolution image loading  with gracefull animations. The animation uses the low res image if the high res is not available, and as soon as the high res is available, it replaces the low res image though a scaling animation (if needed)
- A `close` event is emitted in order to trigger code when the viewer exits the view