### PR TITLE
Added no-border attribute to the ion-header

### DIFF
--- a/src/image-viewer.component.ts
+++ b/src/image-viewer.component.ts
@@ -23,7 +23,7 @@ import { ImageViewerEnter, ImageViewerLeave } from './image-viewer-transitions';
 @Component({
 	selector: 'image-viewer',
 	template: `
-		<ion-header>
+		<ion-header no-border>
 			<ion-navbar>
 			</ion-navbar>
 		</ion-header>


### PR DESCRIPTION
When closing the image, the border of the ion-header (where the arrow is located) is visible.
This can be solved simply by adding the no-border attribute to the ion-header in the template.