### PR TITLE
Fix rxjs imports for better treeshaking

### DIFF
--- a/src/image-viewer-impl.ts
+++ b/src/image-viewer-impl.ts
@@ -1,4 +1,5 @@
-import { delay, zip } from 'rxjs/operators';
+import { delay } from 'rxjs/operators/delay';
+import { zip } from 'rxjs/operators/zip';
 
 import { App, Config, NavOptions, ViewController } from 'ionic-angular';
 import { Observable } from 'rxjs/Observable';


### PR DESCRIPTION
When importing from "rxjs/operators" webpack tree-shaking is not working (by default) properly. Better to import modules for specific methods. Read more:
https://github.com/ReactiveX/rxjs/blob/master/doc/lettable-operators.md#build-and-treeshaking

So with default webpack configuration, all rxjs package is included in the bundle...