### PR TITLE
CSS for iPhone X

### DIFF
--- a/src/image-viewer.scss
+++ b/src/image-viewer.scss
@@ -19,6 +19,11 @@ image-viewer.ion-page {
 
         &.toolbar.toolbar-ios {
             padding-top: calc(20px + 4px);
+            padding-top: calc(constant(safe-area-inset-top) + 4px);
+            padding-top: calc(env(safe-area-inset-top) + 4px);
+            min-height: calc(44px + 20px);
+            min-height: calc(44px + constant(safe-area-inset-top));
+            min-height: calc(44px + env(safe-area-inset-top));
         }
 
         .bar-button-default {

--- a/src/image-viewer.scss
+++ b/src/image-viewer.scss
@@ -21,9 +21,6 @@ image-viewer.ion-page {
             padding-top: calc(20px + 4px);
             padding-top: calc(constant(safe-area-inset-top) + 4px);
             padding-top: calc(env(safe-area-inset-top) + 4px);
-            min-height: calc(44px + 20px);
-            min-height: calc(44px + constant(safe-area-inset-top));
-            min-height: calc(44px + env(safe-area-inset-top));
         }
 
         .bar-button-default {


### PR DESCRIPTION
I had some problems when using the plugin on iPhoneX.
The padding on top of navbar is to small, and you end up pressing the clock in statusbar instead of back button.

See https://webkit.org/blog/7929/designing-websites-for-iphone-x/ for more info on safe-area-inset on iPhoneX. 

The changes should also be compatible with "browsers" not supporting safe-area-inset.